### PR TITLE
Enable code focus plugin

### DIFF
--- a/README.md
+++ b/README.md
@@ -11,6 +11,7 @@ It supports advanced features such as:
 * ✅ **Tables** rendered from Markdown
 * ✅ **Math equations** using MathJax
 * ✅ **Syntax highlighting** with support for line highlighting (`[2|4-6]`)
+* ✅ **Step-by-step code focus** via Reveal.js `code-focus` plugin
 * ✅ **Highlight.js themes** loaded from CDN or local fallback
 * ✅ Project modular structure for easy customization
 
@@ -65,6 +66,7 @@ show_header_trail=true
 
 # Highlight.js theme (examples: monokai, atom-one-light, dracula, github)
 highlight_theme=atom-one-light
+enable_code_focus=true
 
 # Fonts
 font_base=28px
@@ -222,6 +224,20 @@ Highlight specific lines in code blocks:
     print("Line 4")
     ````
 ````
+
+### Code Focus Plugin
+
+Enable the official `code-focus` plugin to step through highlighted lines. Set `enable_code_focus=true` in `config.properties` and use bracket notation to define each step:
+
+```java [2|4-6]
+class Calculator {
+    int screen;
+
+    void add(int a, int b) {
+        screen = a + b;
+    }
+}
+```
 
 
 ---

--- a/config.properties
+++ b/config.properties
@@ -15,6 +15,7 @@ max_scale=2.0
 enable_fragments=true
 show_header_trail=true
 highlight_theme=atom-one-light
+enable_code_focus=true
 font_base=28px
 font_h1=2.5em
 font_h2=2em

--- a/templates/reveal_template.html
+++ b/templates/reveal_template.html
@@ -16,6 +16,9 @@
     <link rel="stylesheet" href="https://cdn.jsdelivr.net/gh/highlightjs/cdn-release@11.7.0/build/styles/{{ highlight_theme }}.min.css">
     {% endif %}
     <script src="{{ reveal_cdn }}/{{ reveal_version }}/plugin/highlight/highlight.js"></script>
+    {% if enable_code_focus == "true" %}
+    <script src="{{ reveal_cdn }}/{{ reveal_version }}/plugin/code-focus/code-focus.js"></script>
+    {% endif %}
 
     <!-- MathJax -->
     <script src="{{ reveal_cdn }}/{{ reveal_version }}/plugin/math/math.min.js"></script>
@@ -110,7 +113,7 @@
             margin: {{ margin }},
             minScale: {{ min_scale }},
             maxScale: {{ max_scale }},
-            plugins: [ RevealMath.MathJax3, RevealHighlight ]
+            plugins: [ RevealMath.MathJax3, RevealHighlight{% if enable_code_focus == "true" %}, RevealCodeFocus{% endif %} ]
         });
 
         const breadcrumb = document.getElementById("header-trail");


### PR DESCRIPTION
## Summary
- add `enable_code_focus` option in `config.properties`
- load Reveal.js code-focus plugin from the template when enabled
- document the new option and usage in README

## Testing
- `python -m py_compile marp_to_reveal.py utils/config_loader.py`
- `python marp_to_reveal.py examples/demo_presentation.md` *(fails: ModuleNotFoundError)*

------
https://chatgpt.com/codex/tasks/task_e_688d48c1037c83278a3af3cab657b88b